### PR TITLE
Don't create new internal key when setting the monkey toggle

### DIFF
--- a/MonkeyLoader.GamePacks.ResoniteModLoader/ModConfigurationDefinitionBuilder.cs
+++ b/MonkeyLoader.GamePacks.ResoniteModLoader/ModConfigurationDefinitionBuilder.cs
@@ -1,3 +1,4 @@
+using EnumerableToolkit;
 using FrooxEngine;
 using HarmonyLib;
 using MonkeyLoader.Configuration;
@@ -120,14 +121,6 @@ namespace ResoniteModLoader
                     return false;
 
                 enabledToggle = potentialKeys[0];
-            }
-
-            if (makeInternal && !enabledToggle.InternalAccessOnly)
-            {
-                _keys.Remove(enabledToggle);
-
-                enabledToggle = new ModConfigurationKey<bool>(enabledToggle.Name, enabledToggle.Description, () => true, true);
-                _keys.Add(enabledToggle);
             }
 
             enabledToggleKey = enabledToggle.Key;

--- a/MonkeyLoader.GamePacks.ResoniteModLoader/ModConfigurationDefinitionBuilder.cs
+++ b/MonkeyLoader.GamePacks.ResoniteModLoader/ModConfigurationDefinitionBuilder.cs
@@ -93,7 +93,7 @@ namespace ResoniteModLoader
                 .Do(ProcessField);
         }
 
-        internal bool TryGetEnabledToggle([NotNullWhen(true)] out DefiningConfigKey<bool>? enabledToggleKey, bool makeInternal = true)
+        internal bool TryGetEnabledToggle([NotNullWhen(true)] out DefiningConfigKey<bool>? enabledToggleKey)
         {
             enabledToggleKey = null;
             ModConfigurationKey<bool>? enabledToggle = null;

--- a/MonkeyLoader.GamePacks.ResoniteModLoader/ModConfigurationDefinitionBuilder.cs
+++ b/MonkeyLoader.GamePacks.ResoniteModLoader/ModConfigurationDefinitionBuilder.cs
@@ -1,4 +1,3 @@
-using EnumerableToolkit;
 using FrooxEngine;
 using HarmonyLib;
 using MonkeyLoader.Configuration;


### PR DESCRIPTION
Creating an internal key breaks changed events, skipping this allows the keys to work correctly and doesn't break visual look of RML mod configs