### PR TITLE
Update Resonite SDK and add Lib.Harmony reference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,15 +1,6 @@
 <Project>
   <PropertyGroup>
     <ResoniteInstallOnBuild Condition="'$(ResoniteInstallOnBuild)'==''">true</ResoniteInstallOnBuild>
-
-    <RestoreAdditionalProjectSources>
-      https://nuget.pkg.github.com/ResoniteModdingGroup/index.json
-    </RestoreAdditionalProjectSources>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/MonkeyLoader.GamePacks.ResoniteModLoader/MonkeyLoader.GamePacks.ResoniteModLoader.csproj
+++ b/MonkeyLoader.GamePacks.ResoniteModLoader/MonkeyLoader.GamePacks.ResoniteModLoader.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Remora.Resonite.Sdk/2.0.10">
+﻿<Project Sdk="Remora.Resonite.Sdk/2.3.0">
   <PropertyGroup>
     <AssemblyTitle>ResoniteModLoader</AssemblyTitle>
     <AssemblyName>ResoniteModLoader</AssemblyName>
@@ -7,20 +7,22 @@
     <!-- We have to do the references manually and hide them,
     as otherwise all of ML and the Integration will get pulled into RML projects referencing this.-->
     <IsMonkeyLoaderGamePack>true</IsMonkeyLoaderGamePack>
+    <MonkeyLoaderHideResoniteIntegration>true</MonkeyLoaderHideResoniteIntegration>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>MonkeyLoader.GamePacks.ResoniteModLoader</PackageId>
     <Title>ResoniteModLoader</Title>
-    <Authors>Banane9, Nytra</Authors>
+    <Authors>Banane9;Nytra</Authors>
     
     <!-- We use the fourth digit for updates since RML uses the first three -->
-    <Version>5.0.1</Version>
+    <Version>5.0.1.1</Version>
     
     <Description>This MonkeyLoader Game Pack for Resonite enables loading ResoniteModLoader mods as MonkeyLoader mods.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ResoniteModdingGroup/MonkeyLoader.GamePacks.ResoniteModLoader</PackageProjectUrl>
+    <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/ResoniteModdingGroup/MonkeyLoader.GamePacks.ResoniteModLoader/master/Icon.png</PackageIconUrl>
     <PackageIcon>/Icon.png</PackageIcon>
     <PackageTags>mod; mods; modding; mod; loader; monkeyloader; resonite; integration; rml; resonitemodloader</PackageTags>
@@ -39,11 +41,9 @@
     <ResoniteReference Include="Elements.Data" />
     <ResoniteReference Include="Elements.Assets" />
     <ResoniteReference Include="FrooxEngine" />
+  </ItemGroup>
 
-    <PackageReference Include="MonkeyLoader.GamePacks.Resonite" Version="0.30.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <!-- Reference the pre-patcher assembly from the Game Pack because PackageReference is stupid -->
-    <Reference Include="MonkeyLoader.Resonite.Data">
-      <HintPath>$(PkgMonkeyLoader_GamePacks_Resonite)\lib\net10.0\pre-patchers\MonkeyLoader.Resonite.Data.dll</HintPath>
-    </Reference>
+  <ItemGroup>
+    <PackageReference Include="Lib.Harmony" Version="2.4.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This makes it the same as the ResoniteModLoader package which also references Lib.Harmony (not thin)